### PR TITLE
Prefer vendedora role when attaching salesperson access

### DIFF
--- a/src/components/sales/SalespersonPanel.tsx
+++ b/src/components/sales/SalespersonPanel.tsx
@@ -12,6 +12,7 @@ import { Plus, Download, Upload, Save, Target, Edit, Trash2 } from "lucide-react
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
+import { fetchSalespersonRole } from "@/utils/salespersonRole";
 import { useSalesData } from "@/hooks/useSalesData";
 
 interface Salesperson {
@@ -40,25 +41,6 @@ interface SalesData {
     goal: number;
   };
 }
-
-const fetchSalespersonRole = async (): Promise<{ id: string }> => {
-  const { data, error } = await supabase
-    .from('papeis')
-    .select<{ id: string }>('id')
-    .ilike('nome', 'vendedor%')
-    .order('nome', { ascending: true })
-    .limit(1);
-
-  if (error) throw error;
-
-  const role = data?.[0];
-
-  if (!role) {
-    throw new Error('Papel de vendedora não encontrado');
-  }
-
-  return role;
-};
 
 export function SalespersonPanel() {
   const {

--- a/src/utils/salespersonRole.ts
+++ b/src/utils/salespersonRole.ts
@@ -1,0 +1,24 @@
+import { supabase } from "@/integrations/supabase/client";
+
+interface SalespersonRole {
+  id: string;
+  nome: string;
+}
+
+export const fetchSalespersonRole = async (): Promise<{ id: string }> => {
+  const { data, error } = await supabase
+    .from('papeis')
+    .select<SalespersonRole>('id, nome')
+    .in('nome', ['vendedora', 'vendedor']);
+
+  if (error) throw error;
+
+  const role = data?.find((papel) => papel.nome === 'vendedora')
+    ?? data?.find((papel) => papel.nome === 'vendedor');
+
+  if (!role) {
+    throw new Error('Papel de vendedora/vendedor não encontrado');
+  }
+
+  return { id: role.id };
+};


### PR DESCRIPTION
## Summary
- replace the salesperson role lookup with a shared helper that prioritizes the "vendedora" role while falling back to "vendedor"
- apply the helper inside the salesperson panel and pessoas page so entity role attachments always use the same role id
- skip duplicate salesperson role inserts when both labels are selected

## Testing
- npm run lint *(fails: existing lint violations throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d7261864cc832ca812cec24dd0b8c8