### PR TITLE
Fix case-insensitive salesperson role lookup

### DIFF
--- a/src/utils/salespersonRole.ts
+++ b/src/utils/salespersonRole.ts
@@ -9,12 +9,12 @@ export const fetchSalespersonRole = async (): Promise<{ id: string }> => {
   const { data, error } = await supabase
     .from('papeis')
     .select<SalespersonRole>('id, nome')
-    .in('nome', ['vendedora', 'vendedor']);
+    .ilike('nome', 'vendedor%');
 
   if (error) throw error;
 
-  const role = data?.find((papel) => papel.nome === 'vendedora')
-    ?? data?.find((papel) => papel.nome === 'vendedor');
+  const role = data?.find((papel) => papel.nome.toLowerCase() === 'vendedora')
+    ?? data?.find((papel) => papel.nome.toLowerCase() === 'vendedor');
 
   if (!role) {
     throw new Error('Papel de vendedora/vendedor não encontrado');


### PR DESCRIPTION
## Summary
- make the salesperson role query case-insensitive to catch capitalized names
- normalize role comparisons when choosing between "vendedora" and "vendedor"

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d72ebb58dc832c9d5c69018c8c3e74